### PR TITLE
Refactor extend and enable new bonds within existing polymer

### DIFF
--- a/polytop/polytop/atoms.py
+++ b/polytop/polytop/atoms.py
@@ -103,7 +103,12 @@ class Atom:
 
     @property 
     def index(self) -> int:
-        return int(re.sub("[^0-9]", "", self.atom_name))
+        index = re.sub("[^0-9]", "", self.atom_name)
+        if index != "":
+            return int(index)
+        else:
+            return self.atom_id
+        #return int(re.sub("[^0-9]", "", self.atom_name))
     
     @index.setter
     def index(self, value: int):

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -15,6 +15,7 @@ def test_invalid_section_warning(data_dir: Path):
     with pytest.warns(UserWarning, match="Unknown section"):
         Topology.from_ITP(data_dir/"invalid_section.itp")
 
+@pytest.mark.xfail(reason="Refactored atom index for RDKit to not rely on atom name")
 def test_glucose_missing_index(data_dir: Path):
     with pytest.raises(ValueError, match="No index"):
         Topology.from_ITP(data_dir/"glucose_faulty.itp")


### PR DESCRIPTION
Just getting this up for review please @khiron. Still needs some testing and cleaning up, which I'll get stuck into now.

I would also like to remove the atom index check in the atom name (in atoms.py, line 64) as I don't believe it is critical? It's causing issues for valid ITP files that have specific atoms named without a number (e.g. HB) and we don't need its number for anything that I can see as we just use the index.

I also cleaned up a buggy import in the topology tests. 