### PR TITLE
Adjustments to charge maintenance method

### DIFF
--- a/polytop/polytop/atoms.py
+++ b/polytop/polytop/atoms.py
@@ -151,7 +151,7 @@ class Atom:
         )
 
     def __str__(self):
-        return f"{self.atom_id:5} {self.atom_type:5} {self.residue_id:5} {self.residue_name:5} {self.atom_name:5} {self.charge_group_num:5} {self.partial_charge:9.3f} {self.mass:9.4f}"
+        return f"{self.atom_id:5} {self.atom_type:5} {self.residue_id:5} {self.residue_name:5} {self.atom_name:5} {self.charge_group_num:5} {self.partial_charge:9.6f} {self.mass:9.4f}"
 
     def __repr__(self) -> str:
         return f"{self.residue_name}.{self.atom_name}->[{','.join([f'{bond.other_atom(self).residue_name}.{bond.other_atom(self).atom_name}' for bond in self.bonds])}]"

--- a/polytop/polytop/topology.py
+++ b/polytop/polytop/topology.py
@@ -396,9 +396,12 @@ class Topology:
         the charge distribution), use the function proportional_charge_change instead.
         """
         old_netcharge = self.netcharge
-        charge_difference_per_atom = (new_netcharge - old_netcharge) / len(self.atoms)
+        num_atoms_to_distribute = len(list(atom for atom in self.atoms if atom.residue_id == self.max_residue_id()))
+        num_atoms_to_distribute += len(list(atom for atom in self.atoms if atom.residue_id == (self.max_residue_id()-1)))
+        charge_difference_per_atom = (new_netcharge - old_netcharge) / num_atoms_to_distribute
         for atom in self.atoms:
-            atom.partial_charge += charge_difference_per_atom
+            if atom.residue_id == self.max_residue_id() or atom.residue_id == (self.max_residue_id()-1):
+                atom.partial_charge += charge_difference_per_atom
 
     def proportional_charge_change(self, new_netcharge):
         """


### PR DESCRIPTION
Adjust the charge maintenance methodology to just distribute lost charges amongst the residues just bound by the extend function only, rather than the whole polymer. This will prevent the buildup of a charge gradient. Additionally, increase the number of decimal places of partial charges that are saved to ITPs for greater accuracy.