### PR TITLE
Correct ordering of atoms in ITP output for GROMACS

### DIFF
--- a/polytop/polytop/atoms.py
+++ b/polytop/polytop/atoms.py
@@ -49,6 +49,7 @@ class Atom:
         formerly = None
     ) -> None:
         self.atom_id = atom_id
+        self.rank = atom_id
         self.atom_type = atom_type
         self.residue_id = residue_id
         self.residue_name = residue_name


### PR DESCRIPTION
Correct atom indexing and ordering before saving to ITP to ensure all atom indexes are contiguous. Additionally, set atom charge group numbering for ITP output so that each atom has its own charge group - this will prevent any possible issues from GROMACS trying to interpret atoms with corresponding charge groups spread along the polymer.