### PR TITLE
Add path to Sphinx configuration file for ReadTheDocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -2,7 +2,7 @@
 
 version: 2
 sphinx:
-  configuration: docs/conf.py
+  configuration: docs/source/conf.py
 
 build:
   os: ubuntu-22.04

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,6 +1,8 @@
 # readthedocs.yaml
 
 version: 2
+sphinx:
+  configuration: docs/conf.py
 
 build:
   os: ubuntu-22.04


### PR DESCRIPTION
Add path to Sphinx configuration file for ReadTheDocs, after ReadTheDocs automatic search was deprecated. Read more [here](https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/)