### PR TITLE
Protect repository from unapproved changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,9 @@
 
 * @lunamorrow @khiron @recombinatrix @RangikaM
 
-/polyconf/ @ada
+/polyconf/ @lunamorrow @recombinatrix
+/polytop/ @lunamorrow @khiron
+/polybuild/ @lunamorrow @RangikaM
 
 # information on how to adjust the code owners can be found here:
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# code owners who may approve any commits to the PolyConstruct repository
+
+* @lunamorrow @khiron @recombinatrix @RangikaM
+
+/polyconf/ @ada
+
+# information on how to adjust the code owners can be found here:
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

--- a/docs/CODEOWNERS
+++ b/docs/CODEOWNERS
@@ -1,0 +1,10 @@
+# code owners who may approve any commits to the PolyConstruct repository
+
+* @lunamorrow @khiron @recombinatrix @RangikaM
+
+/polyconf/ @lunamorrow @recombinatrix
+/polytop/ @lunamorrow @khiron
+/polybuild/ @lunamorrow @RangikaM
+
+# information on how to adjust the code owners can be found here:
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners


### PR DESCRIPTION
Added a CODEOWNERS file into both /docs/ and .github/ folder to protect the repository against unapproved changes. I can approve changes for the whole repository, in addition to @khiron for PolyTop, @recombinatrix for PolyConf and @RangikaM for PolyBuild. I have also put together a PR ruleset to help enforce this. Everyone in @OMaraLab/omara-squad should be able to merge PRs without approval, but please ping me if this is not working.