### PR TITLE
Fix PolyConf dihedral_solver() bug and quiet irrelevant warnings

### DIFF
--- a/polyconf/polyconf/PDB.py
+++ b/polyconf/polyconf/PDB.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-
+import warnings
 import MDAnalysis as mda
     
 class PDB:
@@ -53,6 +53,10 @@ class PDB:
                 defaults to False
         :type gmx: bool, optional
         """
+        # ignore MDAnalysis "UserWarning: Found no information for attr: 'formalcharges' Using default value of '0'"
+        warnings.simplefilter('ignore', category=UserWarning, lineno=1154)
+        # ignore MDAnalysis "UserWarning: Found missing chainIDs. Corresponding atoms will use value of 'X'"
+        warnings.simplefilter('ignore', category=UserWarning, lineno=1201)
         if selectionString:
             if gmx:
                 self.select_atoms(f"{selectionString} and not name {dummies}").atoms._write(f"{fname}.gro")

--- a/polyconf/polyconf/Polymer.py
+++ b/polyconf/polyconf/Polymer.py
@@ -446,6 +446,7 @@ class Polymer:
                             if i==0: # yes, and this is the first monomer
                                 failed=True
                                 done=True
+                                i=-1 # force exit from while loops upon failure
                             else: # yes, and this is not the first monomer
                                 #print(i,tries[i])
                                 retry=True


### PR DESCRIPTION
Changes in this PR:

- [x] Ignore MDAnalysis PDB writer UserWarnings about missing formalcharge or chainID attributes so users do not have to worry about irrelevant warnings, as these datatypes are not required by PolyConf
- [x] Fix PolyConf Polymer.dihedral_solver() bug where it does not exit correctly if the first monomer can't be solved

Will resolve issues #69 and #70

The dihedral_solver() function bug is now gone with a bandaid fix, but I would like to overhaul its method in the near future. It currently has a pair of nested while loops which are *not* friendly towards maintenance and future development of PolyConf.