### PR TITLE
Add polytop example outputs to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,8 @@ polyconf_examples/PEI_linear_*
 polyconf_examples/PEI_branched_*
 polyconf_examples/PEI_randombranched_*
 polyconf_examples/PMMA_*
+
+# Output of polytop tutorial
+polytop_examples/data/ethylamine_dendrimer.*
+polytop_examples/data/four_arm_star.*
+polytop_examples/data/pei_linear_polymer.*


### PR DESCRIPTION
Files generated by examples should be added to gitignore.

This is so that they are not accidentally added to the repository.  If outputs are contained in the repository there is a risk that incorrect scripts will appear to have executed correctly, as the output files will be present.